### PR TITLE
Fix k sprintf k printf garbage char issue

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -187,6 +187,7 @@ int k_sprintf(char *str, const char *fmt, ...) {
 	sp += sizeof(const char*);
 
 	int int_temp;
+	unsigned int uint_temp;
 	char char_temp;
 	char *string_temp;
 	double double_temp;
@@ -216,8 +217,8 @@ int k_sprintf(char *str, const char *fmt, ...) {
 					sp += sizeof (int);
 					break;
 				case 'x':
-					int_temp = *(int *)sp;
-					k_itoa(int_temp, buffer, 16);
+					uint_temp = *(unsigned int *)sp;
+					k_utoa(uint_temp, buffer, 16);
 					k_strcat(str, buffer);
 					l += k_strlen(buffer);
 					sp += sizeof (int);

--- a/kstring.c
+++ b/kstring.c
@@ -205,6 +205,7 @@ int k_sprintf(char *str, const char *fmt, ...) {
 					break;
 				case 's':
 					string_temp = *(char **)sp;
+					str[l] = NULL;
 					k_strcat(str, string_temp);
 					l += k_strlen(string_temp);
 					sp += sizeof (char *);
@@ -212,6 +213,7 @@ int k_sprintf(char *str, const char *fmt, ...) {
 				case 'd':
 					int_temp = *(int *)sp;
 					k_itoa(int_temp, buffer, 10);
+					str[l] = NULL;
 					k_strcat(str, buffer);
 					l += k_strlen(buffer);
 					sp += sizeof (int);
@@ -219,6 +221,7 @@ int k_sprintf(char *str, const char *fmt, ...) {
 				case 'x':
 					uint_temp = *(unsigned int *)sp;
 					k_utoa(uint_temp, buffer, 16);
+					str[l] = NULL;
 					k_strcat(str, buffer);
 					l += k_strlen(buffer);
 					sp += sizeof (int);


### PR DESCRIPTION
The issue was the in k_sprintf function, the code is written as:
				case 'x':
					uint_temp = *(unsigned int *)sp;
					k_utoa(uint_temp, buffer, 16);
					/////// this line is not in buggy code: str[l] = NULL;
					k_strcat(str, buffer);
					l += k_strlen(buffer);
					sp += sizeof (int);

the str doesn't have \0 set properly before k_strcat() call, so that the strcat concat the string to the wrong end (maybe very hard away from the position it shall be)
